### PR TITLE
feat: Add settings plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,37 @@ custom-maven-repository = { id = "com.akexorcist.maven.repository.custom", versi
 
 ### Plugin declaration
 
+There are two ways to declare the plugin in your Gradle project: using the build script DSL or the settings script DSL.
+
+#### Build script DSL
+
 ```kotlin
 // Top-level build.gradle.kts
 plugins {
     id("com.akexorcist.maven.repository.custom") version "1.0.0"
+}
+```
+
+#### Settings script DSL
+
+```kotlin
+// Top-level settings.gradle.kts
+plugins {
+    id("com.akexorcist.maven.repository.custom.settings") version "1.0.0"
+}
+
+extensions.configure<com.akexorcist.maven.repository.custom.CustomMavenRepositoryExtension> { // configure the custom Maven repository extension used by the plugin
+    repositoryUrl = "Your Maven repository URL"
+    usernameKey = "Variable key for Maven repository username"
+    passwordKey = "Variable key for Maven repository password"
+    macOsKeyChain = CustomMavenRepositoryExtension.MacOsKeyChain(
+        accountName = "macOS Keychain's account name",
+        key = "macOS Keychain's key",
+    )
+}
+
+dependencyResolutionManagement { // optional
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS) // Someone may want to use `RepositoriesMode.PREFER_SETTINGS` instead
 }
 ```
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,10 +1,12 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.plugins.signing.SigningExtension
 
 plugins {
     `kotlin-dsl`
     id("com.vanniktech.maven.publish") version "0.31.0"
+    `signing`
 }
 
 repositories {
@@ -44,6 +46,10 @@ gradlePlugin {
             id = "com.akexorcist.maven.repository.custom"
             implementationClass = "com.akexorcist.maven.repository.custom.CustomMavenRepositoryPlugin"
         }
+        register("customMavenRepositorySettingsPlugin") {
+            id = "com.akexorcist.maven.repository.custom.settings"
+            implementationClass = "com.akexorcist.maven.repository.custom.CustomMavenRepositorySettingsPlugin"
+        }
     }
 }
 
@@ -79,6 +85,24 @@ mavenPublishing {
             url.set("https://github.com/akexorcist/custom-maven-repository-gradle-plugin")
             connection.set("scm:git:git://github.com/akexorcist/custom-maven-repository-gradle-plugin.git")
             developerConnection.set("scm:git:ssh://git@github.com/akexorcist/custom-maven-repository-gradle-plugin.git")
+        }
+    }
+}
+
+// Configure signing using macOS Keychain
+afterEvaluate {
+    configure<SigningExtension> {
+        // Check if we have explicit properties configured
+        val signingKeyId = getProjectVariable("signing.keyId")
+        val signingPassword = getProjectVariable("signing.password")
+        val signingSecretKeyRingFile = getProjectVariable("signing.secretKeyRingFile")
+
+        // If explicit signing properties are provided, use them
+        if (signingKeyId != null && signingPassword != null && signingSecretKeyRingFile != null) {
+            useInMemoryPgpKeys(signingKeyId, signingSecretKeyRingFile, signingPassword)
+        } else {
+            // Otherwise, try to use macOS Keychain
+            useGpgCmd()
         }
     }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,12 +1,10 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.plugins.signing.SigningExtension
 
 plugins {
     `kotlin-dsl`
     id("com.vanniktech.maven.publish") version "0.31.0"
-    `signing`
 }
 
 repositories {
@@ -85,24 +83,6 @@ mavenPublishing {
             url.set("https://github.com/akexorcist/custom-maven-repository-gradle-plugin")
             connection.set("scm:git:git://github.com/akexorcist/custom-maven-repository-gradle-plugin.git")
             developerConnection.set("scm:git:ssh://git@github.com/akexorcist/custom-maven-repository-gradle-plugin.git")
-        }
-    }
-}
-
-// Configure signing using macOS Keychain
-afterEvaluate {
-    configure<SigningExtension> {
-        // Check if we have explicit properties configured
-        val signingKeyId = getProjectVariable("signing.keyId")
-        val signingPassword = getProjectVariable("signing.password")
-        val signingSecretKeyRingFile = getProjectVariable("signing.secretKeyRingFile")
-
-        // If explicit signing properties are provided, use them
-        if (signingKeyId != null && signingPassword != null && signingSecretKeyRingFile != null) {
-            useInMemoryPgpKeys(signingKeyId, signingSecretKeyRingFile, signingPassword)
-        } else {
-            // Otherwise, try to use macOS Keychain
-            useGpgCmd()
         }
     }
 }

--- a/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/CustomMavenRepositorySettingsPlugin .kt
+++ b/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/CustomMavenRepositorySettingsPlugin .kt
@@ -1,23 +1,23 @@
 package com.akexorcist.maven.repository.custom
 
 import org.gradle.api.Plugin
-import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.initialization.Settings
 import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.repositories
 import pt.davidafsilva.apple.OSXKeychain
 import kotlin.jvm.optionals.getOrNull
 
 @Suppress("unused")
-class CustomMavenRepositoryPlugin : Plugin<Project> {
-    override fun apply(target: Project) {
+class CustomMavenRepositorySettingsPlugin : Plugin<Settings> {
+    override fun apply(target: Settings) {
         with(target) {
             extensions.create("customMavenRepository", CustomMavenRepositoryExtension::class.java)
-            afterEvaluate {
-                repositories {
-                    mavenLocal()
-                    customMaven(target)
+            gradle.beforeProject {
+                dependencyResolutionManagement {
+                    repositories {
+                        customMaven(target)
+                    }
                 }
             }
         }
@@ -25,7 +25,7 @@ class CustomMavenRepositoryPlugin : Plugin<Project> {
 }
 
 fun RepositoryHandler.customMaven(
-    target: Project,
+    target: Settings,
     name: String,
     extension: CustomMavenRepositoryExtension,
 ): MavenArtifactRepository = maven {
@@ -36,7 +36,7 @@ fun RepositoryHandler.customMaven(
     credentials { extension.credentials(this, username, password) }
 }
 
-fun RepositoryHandler.customMaven(target: Project, name: String = "CustomMaven") {
+fun RepositoryHandler.customMaven(target: Settings, name: String = "CustomMaven") {
     val extension: CustomMavenRepositoryExtension = target.extensions.getByType()
     customMaven(
         target = target,

--- a/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/Utils.kt
+++ b/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/Utils.kt
@@ -1,0 +1,40 @@
+package com.akexorcist.maven.repository.custom
+
+import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
+import pt.davidafsilva.apple.OSXKeychain
+import kotlin.jvm.optionals.getOrNull
+
+internal fun isMacOs() = System.getProperty("os.name").lowercase().contains("mac")
+internal fun isGitLabRunner() = System.getProperty("GITLAB_CI") != null
+
+internal fun getPasswordFromKeychain(keyChain: CustomMavenRepositoryExtension.MacOsKeyChain): String? {
+    return runCatching {
+        val chain = OSXKeychain.getInstance()
+        chain.findGenericPassword(keyChain.key, keyChain.accountName).getOrNull()
+    }.getOrNull()
+}
+
+
+internal fun Settings.getCredential(extension: CustomMavenRepositoryExtension): Pair<String?, String?> {
+    val macOsKeyChain = extension.macOsKeyChain
+    return getSettingsVariable(extension.usernameKey) to when {
+        macOsKeyChain != null && isMacOs() && !isGitLabRunner() -> getPasswordFromKeychain(macOsKeyChain)
+        else -> getSettingsVariable(extension.passwordKey)
+    }
+}
+
+fun Settings.getSettingsVariable(key: String) = System.getenv(key)
+    ?.takeIf { it.isNotBlank() } ?: providers.gradleProperty(key).get()
+
+internal fun Project.getCredential(extension: CustomMavenRepositoryExtension): Pair<String?, String?> {
+    val macOsKeyChain = extension.macOsKeyChain
+    return getProjectVariable(extension.usernameKey) to when {
+        macOsKeyChain != null && isMacOs() && !isGitLabRunner() -> getPasswordFromKeychain(macOsKeyChain)
+        else -> getProjectVariable(extension.passwordKey)
+    }
+}
+
+
+fun Project.getProjectVariable(key: String) = System.getenv(key)
+    ?.takeIf { it.isNotBlank() } ?: properties[key]?.toString().takeIf { !it.isNullOrBlank() }


### PR DESCRIPTION
1. Add `CustomMavenRepositorySettingsPlugin` which will allow to apply a plugin on `settings.gradle(.kts)`. Some projects prefer to manage dependency resolution via settings instead of an individual project via build script (`build.gradle(.kts)`)
#### Usage example:
```kotlin
// Top-level settings.gradle.kts
plugins {
    id("com.akexorcist.maven.repository.custom.settings") version "1.0.0"
}

extensions.configure<com.akexorcist.maven.repository.custom.CustomMavenRepositoryExtension> { // configure the custom Maven repository extension used by the plugin
    repositoryUrl = "Your Maven repository URL"
    usernameKey = "Variable key for Maven repository username"
    passwordKey = "Variable key for Maven repository password"
    macOsKeyChain = CustomMavenRepositoryExtension.MacOsKeyChain(
        accountName = "macOS Keychain's account name",
        key = "macOS Keychain's key",
    )
}

dependencyResolutionManagement { // optional
    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS) // Someone may want to use `RepositoriesMode.PREFER_SETTINGS` instead
}
```
2. Refactor shared function to `Utils.kt`.