### PR TITLE
fix: Gradle run fail due to incorrect call in plugin

### DIFF
--- a/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/CustomMavenRepositorySettingsPlugin .kt
+++ b/plugin/src/main/kotlin/com/akexorcist/maven/repository/custom/CustomMavenRepositorySettingsPlugin .kt
@@ -13,7 +13,7 @@ class CustomMavenRepositorySettingsPlugin : Plugin<Settings> {
     override fun apply(target: Settings) {
         with(target) {
             extensions.create("customMavenRepository", CustomMavenRepositoryExtension::class.java)
-            gradle.beforeProject {
+            gradle.settingsEvaluated {
                 dependencyResolutionManagement {
                     repositories {
                         customMaven(target)


### PR DESCRIPTION
Fix Gradle run fail. This is caused by using `gradle.beforeProject` in `Settings`. It should use `gradle.settingsEvaluated` instead.